### PR TITLE
avoid yield in magic method for hhvm

### DIFF
--- a/src/Psr4List.php
+++ b/src/Psr4List.php
@@ -9,9 +9,23 @@ namespace Koriym\Psr4List;
 class Psr4List
 {
     /**
+     * @param string $prefix
+     * @param string $path
+     *
      * @return \Generator
      */
     public function __invoke($prefix, $path)
+    {
+        return $this->invoke($prefix, $path);
+    }
+
+    /**
+     * @param string $prefix
+     * @param string $path
+     *
+     * @return \Generator
+     */
+    private function invoke($prefix, $path)
     {
         foreach ($this->files($path) as $item) {
             /** @var $item \SplFileInfo */


### PR DESCRIPTION
avoid "Fatal error: 'yield' is not allowed in constructor, destructor, or magic methods" in hhvm.
