### PR TITLE
Fix IteratorAggregate return type compatibility for PHP 8.1+

### DIFF
--- a/src/SortingIterator.php
+++ b/src/SortingIterator.php
@@ -8,6 +8,7 @@ use ArrayIterator;
 use IteratorAggregate;
 use RegexIterator;
 use SplFileInfo;
+use Traversable;
 
 use function count;
 use function explode;
@@ -29,7 +30,8 @@ class SortingIterator implements IteratorAggregate
             /** @return int */
             static function (SplFileInfo $a, SplFileInfo $b) {
                 $pathA = str_replace('\\', '/', $a->getPathname());
-                $pathB = str_replace('\\', '/', $b->getPathname());                $cntA = count(explode('/', $pathA));
+                $pathB = str_replace('\\', '/', $b->getPathname());
+                $cntA = count(explode('/', $pathA));
                 $cntB = count(explode('/', $pathB));
                 if ($cntA !== $cntB) {
                     return $cntA > $cntB ? 1 : -1;
@@ -43,7 +45,7 @@ class SortingIterator implements IteratorAggregate
     }
 
     /** @return ArrayIterator<int, SplFileInfo> */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         return $this->iterator;
     }


### PR DESCRIPTION
## Summary
- Fixed `SortingIterator::getIterator()` return type to match `IteratorAggregate` interface signature
- Fixed coding style issue (each statement on separate line)

## Problem
PHP 8.1+ shows deprecation warning:
```
Deprecated: Return type of Koriym\Psr4List\SortingIterator::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable
```

## Changes
- Changed return type from `ArrayIterator` to `Traversable` in `SortingIterator::getIterator()`
- Added `use Traversable;` import
- DocBlock still indicates `@return ArrayIterator<int, SplFileInfo>` for static analysis tools
- Fixed line 32-33 formatting issue

## Test plan
- All existing tests pass
- Fixes deprecation warning in PHP 8.1+
- Maintains backward compatibility (ArrayIterator implements Traversable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourceryによる要約

PHP 8.1以降向けに`SortingIterator::getIterator()`のシグネチャが`IteratorAggregate`と一致することを確認し、コードのフォーマットをクリーンアップします。

バグ修正:
- `PHP 8.1`の非推奨警告を回避するため、`getIterator`の戻り値の型を`ArrayIterator`から`Traversable`に変更

改善点:
- `Traversable`のインポートを追加
- 可読性向上のため、コンパレータクロージャ内の結合されたステートメントを個別の行に分離

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure SortingIterator::getIterator() signature matches IteratorAggregate for PHP 8.1+ and clean up code formatting.

Bug Fixes:
- Change getIterator return type from ArrayIterator to Traversable to avoid PHP 8.1 deprecation warning

Enhancements:
- Add Traversable import
- Separate combined statements in comparator closure onto individual lines for improved readability

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of path segment sorting logic.

* **Refactor**
  * Enhanced iterator compatibility with broader interface support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->